### PR TITLE
Fix code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/normalize_url/internal/ip/ip.go
+++ b/normalize_url/internal/ip/ip.go
@@ -30,7 +30,7 @@ func NormalizeIPv4(s string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		resultRow += strconv.Itoa(int(num)) + "."
+		resultRow += strconv.FormatUint(uint64(num), 10) + "."
 	}
 
 	num, err := parseNumber(octets[len(octets)-1], 5-len(octets))


### PR DESCRIPTION
Fixes [https://github.com/DrHazemAli/threat-intelligence/security/code-scanning/1](https://github.com/DrHazemAli/threat-intelligence/security/code-scanning/1)

To fix the problem, we need to ensure that the conversion from `uint32` to `int` is safe and does not result in unexpected values. The best way to achieve this is to avoid the conversion to `int` altogether and use the `strconv.FormatUint` function to convert the `uint32` value directly to a string. This approach maintains the integrity of the value and avoids any potential overflow issues.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
